### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ Installing `npm` is fraught with issues, including but not limited to how to get
             <artifactId>frontend-maven-plugin</artifactId>
             <version>1.6</version>
             <configuration>
-                <nodeVersion>v8.8.1</nodeVersion>
+                <nodeVersion>v9.11.2</nodeVersion>
             </configuration>
             <executions>
                 <execution>


### PR DESCRIPTION
Given version of Node in pom.xml is v8.8.1
However, in the result of './ng --version' command, it is shown as Node: 9.11.2

Running './ng --version' with 8.8.1 version will throw the error "You are running version v8.8.1 of Node.js, which is not supported by Angular CLI v6.
The official Node.js version that is supported is 8.9 and greater.

Please visit https://nodejs.org/en/ to find instructions on how to update Node.js."